### PR TITLE
Fix compile issues against Red Hat 8 kernels

### DIFF
--- a/avp_compat.h
+++ b/avp_compat.h
@@ -44,8 +44,19 @@ typedef phys_addr_t rte_iova_t;
 #endif
 
 #if (RHEL_RELEASE_CODE && (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,5)))
-#define HAVE_RHEL7_EXTENDED_MIN_MAX_MTU
 #define HAVE_VOID_NDO_GET_STATS64
+#endif
+
+/*
+ * RHEL has two different versions with different kernel versions:
+ * 3.10 is for AMD, Intel, IBM POWER7 and POWER8;
+ * 4.14 is for ARM and IBM POWER9
+ */
+#if (defined(RHEL_RELEASE_CODE) && \
+	(RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7, 5)) && \
+	(RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(8, 0)) && \
+	(LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)))
+#define ndo_change_mtu ndo_change_mtu_rh74
 #endif
 
 #else

--- a/avp_net.c
+++ b/avp_net.c
@@ -602,11 +602,7 @@ static const struct net_device_ops avp_net_netdev_ops = {
 	.ndo_stop = avp_net_release,
 	.ndo_set_config = avp_net_config,
 	.ndo_start_xmit = avp_net_tx,
-#ifdef HAVE_RHEL7_EXTENDED_MIN_MAX_MTU
-	.ndo_change_mtu_rh74 = avp_net_change_mtu,
-#else
-	.ndo_change_mtu= avp_net_change_mtu,
-#endif
+	.ndo_change_mtu = avp_net_change_mtu,
 	.ndo_get_stats64 = avp_net_stats,
 #ifdef WRS_AVP_TX_TIMEOUTS
 	.ndo_tx_timeout = avp_net_tx_timeout,


### PR DESCRIPTION
ndo_change_mtu_rh74 is now gone so we change the
cpp macros in avp_compat.h to properly deal with it,
borrowing the same approach from dpdk.

Signed-off-by: Jim Somerville <Jim.Somerville@windriver.com>